### PR TITLE
Misc. tidying

### DIFF
--- a/interactiveUI2.py
+++ b/interactiveUI2.py
@@ -83,20 +83,6 @@ def process_command(command, arguments):
         status = command + ": Operation failed"
 
 
-def vertical_padding(lines):
-    output = ""
-    for i in range(lines):
-        output += "\n"
-    return output
-
-
-def horizontal_padding(cols):
-    output = ""
-    for i in range(cols):
-        output += " "
-    return output
-
-
 quitting = False
 while not quitting:
     cols, lines = shutil.get_terminal_size()
@@ -111,8 +97,9 @@ while not quitting:
         status = "Error: Unknown current_mode!"
 
     used_lines += 2
-    print(vertical_padding(lines-used_lines))
-    termcolor.cprint(" " + status + horizontal_padding(cols-len(status)-1), attrs=['reverse'])
+    print("\n" * (lines - used_lines))
+    status_line = " " + status + (" " * (cols - len(status) - 1))
+    termcolor.cprint(status_line, attrs=['reverse'])
     command, arguments = split_input(input("> "))
     process_command(command, arguments)
 

--- a/interactiveUI2.py
+++ b/interactiveUI2.py
@@ -3,13 +3,14 @@ import shutil
 import os
 import termcolor
 
-print("\x1B[22t") 			#Save window title
 
-listMode, linksMode, helpMode = range(0, 3)
-modeNames = ["Entity List", "Single entity view", "Documentation"]
-viewingMode = listMode
+print("\x1B[22t") # Save window title
 
-print("\x1B]0;%s\x07" % "PIMesh") 
+MODE_LIST, MODE_LINKS, MODE_HELP = range(3)
+mode_names = ["Entity List", "Single entity view", "Documentation"]
+current_mode = MODE_LIST
+
+print("\x1B]0;%s\x07" % "PIMesh") # Set window title
 
 filename = "network0.pimesh"
 
@@ -18,111 +19,109 @@ current_entity = network["cabbage"]
 
 status = "Started PIMesh"
 
-def printEntityList(network):
-  global status
-  try:
+
+def print_entity_list():
+    global status
     for name in network:
-      print(name)
+        print(name)
     return len(network)
-  except:
-    status = "Error encountered while printing entity list"
-    return 3
 
-    
-def printEntityLinks(entity):
-  print(str(entity))
-  return len(current_entity.links)+4
-  
-def printHelp():
-  global status
-  status = "Sorry, help not implemented yet"
-  return 1
-  
-def splitInput(userInput):
-  command, *arguments = userInput.split(" ", 1)
-  if len(arguments) > 0:
-    arguments = arguments[0].split(": ")
-  return command, arguments
 
-def processCommand(command, arguments):
-  global quiting, viewingMode, current_entity, status
-  status = command + ": Operation sucessful"
-  try:
-    if command in ["quit", "exit"]:
-      status = "Exiting by user request..."
-      quiting = True
-    elif command in ["help", "?", "man", "manual"]:
-      viewingMode = helpMode
-      status = "Entered help mode"
-    elif command in ["list", "ls"]:
-      viewingMode = listMode
-      status = "Entered entity list mode"
-    elif command in ["view", "vw"]:
-      viewingMode = linksMode
-      current_entity = network[arguments[0]]
-      status = "Entered entity view mode"
+def print_entity_links(entity):
+    print(str(entity))
+    return len(current_entity.links)+4
 
-    elif command in ["remove", "rm"]:
-      if viewingMode == linksMode:
-        current_entity.unlink(arguments[0], arguments[1])
-      else:
-        status = "Please enter entity view mode using 'view <entity>' and try again"
-    elif command in ["add", "ad"]:
-      if viewingMode == linksMode:
-        current_entity.link(arguments[0], arguments[1])
-      else:
-        status = "Please enter entity view mode using 'view <entity>' and try again"
-    elif command in ["update", "ud"]:
-      if viewingMode == linksMode:
-        current_entity.relink(arguments[0], arguments[1], arguments[2])
-      else:
-        status = "Please enter entity view mode using 'view <entity>' and try again"
-      
+
+def print_help():
+    global status
+    status = "Sorry, help not implemented yet"
+    return 1
+
+
+def split_input(user_input):
+    command, *arguments = user_input.split(" ", 1)
+    if len(arguments) > 0:
+        arguments = arguments[0].split(": ")
+    return command, arguments
+
+
+def process_command(command, arguments):
+    global quitting, current_mode, current_entity, status
+    status = command + ": Operation sucessful"
+    try:
+        if command in ["quit", "exit"]:
+            status = "Exiting by user request..."
+            quitting = True
+        elif command in ["help", "?", "man", "manual"]:
+            current_mode = MODE_HELP
+            status = "Entered help mode"
+        elif command in ["list", "ls"]:
+            current_mode = MODE_LIST
+            status = "Entered entity list mode"
+        elif command in ["view", "vw"]:
+            current_mode = MODE_LINKS
+            current_entity = network[arguments[0]]
+            status = "Entered entity view mode"
+        elif command in ["remove", "rm"]:
+            if current_mode == MODE_LINKS:
+                current_entity.unlink(arguments[0], arguments[1])
+            else:
+                status = "Please enter entity view mode using 'view <entity>' and try again"
+        elif command in ["add", "ad"]:
+            if current_mode == MODE_LINKS:
+                current_entity.link(arguments[0], arguments[1])
+            else:
+                status = "Please enter entity view mode using 'view <entity>' and try again"
+        elif command in ["update", "ud"]:
+            if current_mode == MODE_LINKS:
+                current_entity.relink(arguments[0], arguments[1], arguments[2])
+            else:
+                status = "Please enter entity view mode using 'view <entity>' and try again"
+        else:
+            status = "Error: Unknown command"
+    except:
+        status = command + ": Operation failed"
+
+
+def vertical_padding(lines):
+    output = ""
+    for i in range(lines):
+        output += "\n"
+    return output
+
+
+def horizontal_padding(cols):
+    output = ""
+    for i in range(cols):
+        output += " "
+    return output
+
+
+quitting = False
+while not quitting:
+    cols, lines = shutil.get_terminal_size()
+    os.system("clear")
+    if current_mode == MODE_LIST:
+        used_lines = print_entity_list()
+    elif current_mode == MODE_LINKS:
+        used_lines = print_entity_links(current_entity)
+    elif current_mode == MODE_HELP:
+        used_lines = print_help()
     else:
-      status = "Error: Unknown command"
-  except:
-    status = command + ": Operation failed"
-    
-def verticalPad(lines):
-  output = ""
-  for i in range(lines):
-    output += "\n"
-  return output
-    
-def horizontalPad(cols):
-  output = ""
-  for i in range(cols):
-    output += " "
-  return output
+        status = "Error: Unknown current_mode!"
 
-
-    
-quiting = False
-while not quiting:
-  
-  cols, lines = shutil.get_terminal_size()
-  os.system("clear")
-  if viewingMode == listMode:
-    usedLines = printEntityList(network)
-  elif viewingMode == linksMode:
-    usedLines = printEntityLinks(current_entity)
-  elif viewingMode == helpMode:
-    usedLines = printHelp()
-  else:
-    status = "Error: Unknown viewingMode!"
-
-  usedLines += 2
-  print(verticalPad(lines-usedLines))
-  termcolor.cprint(" " + status + horizontalPad(cols-len(status)-1), attrs=['reverse'])
-  command, arguments = splitInput(input("> "))
-  processCommand(command, arguments)
+    used_lines += 2
+    print(vertical_padding(lines-used_lines))
+    termcolor.cprint(" " + status + horizontal_padding(cols-len(status)-1), attrs=['reverse'])
+    command, arguments = split_input(input("> "))
+    process_command(command, arguments)
 
 
 os.system("clear")
 try:
-  network.to_file(filename)
-  print("Saved session changes to file. \nPIMesh quitting...")
+    network.to_file(filename)
+    print("Saved session changes to file. \nPIMesh quitting...")
 except:
-  print("Saving to file failed!")
-  
-  print("\x1B[23t")		#restore window title
+    print("Saving to file failed!")
+
+print("\x1B[23t")		#restore window title

--- a/interactiveUI2.py
+++ b/interactiveUI2.py
@@ -1,14 +1,20 @@
-from network import EntityNetwork
-import shutil
 import os
+import shutil
 import termcolor
+
+from enum import Enum
+from network import EntityNetwork
 
 
 print("\x1B[22t") # Save window title
 
-MODE_LIST, MODE_LINKS, MODE_HELP = range(3)
-mode_names = ["Entity List", "Single entity view", "Documentation"]
-current_mode = MODE_LIST
+Mode = Enum('Modes', ('list', 'links', 'help'))
+mode_names = {
+    Mode.list: "Entity List",
+    Mode.links: "Single entity view",
+    Mode.help: "Documentation"
+}
+current_mode = Mode.list
 
 print("\x1B]0;%s\x07" % "PIMesh") # Set window title
 
@@ -53,27 +59,27 @@ def process_command(command, arguments):
             status = "Exiting by user request..."
             quitting = True
         elif command in ["help", "?", "man", "manual"]:
-            current_mode = MODE_HELP
+            current_mode = Mode.help
             status = "Entered help mode"
         elif command in ["list", "ls"]:
-            current_mode = MODE_LIST
+            current_mode = Mode.list
             status = "Entered entity list mode"
         elif command in ["view", "vw"]:
-            current_mode = MODE_LINKS
+            current_mode = Mode.links
             current_entity = network[arguments[0]]
             status = "Entered entity view mode"
         elif command in ["remove", "rm"]:
-            if current_mode == MODE_LINKS:
+            if current_mode == Mode.links:
                 current_entity.unlink(arguments[0], arguments[1])
             else:
                 status = "Please enter entity view mode using 'view <entity>' and try again"
         elif command in ["add", "ad"]:
-            if current_mode == MODE_LINKS:
+            if current_mode == Mode.links:
                 current_entity.link(arguments[0], arguments[1])
             else:
                 status = "Please enter entity view mode using 'view <entity>' and try again"
         elif command in ["update", "ud"]:
-            if current_mode == MODE_LINKS:
+            if current_mode == Mode.links:
                 current_entity.relink(arguments[0], arguments[1], arguments[2])
             else:
                 status = "Please enter entity view mode using 'view <entity>' and try again"
@@ -87,11 +93,11 @@ quitting = False
 while not quitting:
     cols, lines = shutil.get_terminal_size()
     os.system("clear")
-    if current_mode == MODE_LIST:
+    if current_mode == Mode.list:
         used_lines = print_entity_list()
-    elif current_mode == MODE_LINKS:
+    elif current_mode == Mode.links:
         used_lines = print_entity_links(current_entity)
-    elif current_mode == MODE_HELP:
+    elif current_mode == Mode.help:
         used_lines = print_help()
     else:
         status = "Error: Unknown current_mode!"

--- a/interactiveUI2.py
+++ b/interactiveUI2.py
@@ -14,7 +14,7 @@ print("\x1B]0;%s\x07" % "PIMesh")
 filename = "network0.pimesh"
 
 network = EntityNetwork.from_file(filename)
-currentEntityName = "cabbage"
+current_entity = network["cabbage"]
 
 status = "Started PIMesh"
 
@@ -31,7 +31,7 @@ def printEntityList(network):
     
 def printEntityLinks(entity):
   print(str(entity))
-  return len(network[currentEntityName].links)+4
+  return len(current_entity.links)+4
   
 def printHelp():
   global status
@@ -45,7 +45,7 @@ def splitInput(userInput):
   return command, arguments
 
 def processCommand(command, arguments):
-  global quiting, viewingMode, currentEntityName, status
+  global quiting, viewingMode, current_entity, status
   status = command + ": Operation sucessful"
   try:
     if command in ["quit", "exit"]:
@@ -59,22 +59,22 @@ def processCommand(command, arguments):
       status = "Entered entity list mode"
     elif command in ["view", "vw"]:
       viewingMode = linksMode
-      currentEntityName = arguments[0]
+      current_entity = network[arguments[0]]
       status = "Entered entity view mode"
 
     elif command in ["remove", "rm"]:
       if viewingMode == linksMode:
-        network[currentEntityName].unlink(arguments[0], arguments[1])
+        current_entity.unlink(arguments[0], arguments[1])
       else:
         status = "Please enter entity view mode using 'view <entity>' and try again"
     elif command in ["add", "ad"]:
       if viewingMode == linksMode:
-        network[currentEntityName].link(arguments[0], arguments[1])
+        current_entity.link(arguments[0], arguments[1])
       else:
         status = "Please enter entity view mode using 'view <entity>' and try again"
     elif command in ["update", "ud"]:
       if viewingMode == linksMode:
-        network[currentEntityName].relink(arguments[0], arguments[1], arguments[2])
+        current_entity.relink(arguments[0], arguments[1], arguments[2])
       else:
         status = "Please enter entity view mode using 'view <entity>' and try again"
       
@@ -105,7 +105,7 @@ while not quiting:
   if viewingMode == listMode:
     usedLines = printEntityList(network)
   elif viewingMode == linksMode:
-    usedLines = printEntityLinks(network[currentEntityName])
+    usedLines = printEntityLinks(current_entity)
   elif viewingMode == helpMode:
     usedLines = printHelp()
   else:


### PR DESCRIPTION
- Indent to four spaces, per pep8.
- Rename lots of things, hopefully ditto.
- Replace padding functions with ("\n" \* n), because Python.
- Use enum for modes.
- Current entity kept as an object, not by name as a string.
